### PR TITLE
feat: 방 정보 controller단, service단, keyerror, typeerror 미들웨어, errorGenerator 유틸함수

### DIFF
--- a/controllers/roomController.js
+++ b/controllers/roomController.js
@@ -1,0 +1,74 @@
+const roomService = require("../servieces/roomService");
+
+const errorGenerator = require("../utils/errorGenerator");
+
+const getRoomName = async (req, res, next) => {
+  try {
+    const { room_id } = req.params;
+
+    const roomName = await roomService.getRoomName(room_id);
+    return res.status(200).json({ roomName });
+  } catch (error) {
+    res.status(error.statusCode || 500).json({ message: error.message });
+  }
+};
+
+const getRoomUsers = async (req, res, next) => {
+  try {
+    const { room_id } = req.params;
+
+    const roomUsers = await roomService.getRoomUsers(room_id);
+    return res.status(200).json({ roomUsers });
+  } catch (error) {
+    res.status(error.statusCode || 500).json({ message: error.message });
+  }
+};
+
+const createRoomName = async (req, res, next) => {
+  try {
+    const roomName = req.room_name;
+
+    if (!roomName.length) {
+      errorGenerator({
+        statusCode: 400,
+        message: "방 이름 길이는 0자 이상이어야 합니다.",
+      });
+    }
+
+    const roomId = await roomService.createRoomName(roomName);
+    return res
+      .status(200)
+      .json({ message: "ROOMNAME ADD SUCCESS", room_id: roomId });
+  } catch (error) {
+    res.status(error.statusCode || 500).json({ message: error.message });
+  }
+};
+
+const patchRoomName = async (req, res, next) => {
+  try {
+    const { room_id } = req.params;
+    const roomName = req.room_name;
+
+    if (!roomName.length) {
+      errorGenerator({
+        statusCode: 400,
+        message: "방 이름 길이는 0자 이상이어야 합니다.",
+      });
+    }
+
+    const roomId = await roomService.patchRoomName(room_id, roomName);
+    return res.status(200).json({
+      message: "ROOMNAME UPDATE SUCCESS",
+      room_id: roomId,
+    });
+  } catch (error) {
+    res.status(error.statusCode || 500).json({ message: error.message });
+  }
+};
+
+module.exports = {
+  getRoomName,
+  getRoomUsers,
+  createRoomName,
+  patchRoomName,
+};

--- a/controllers/roomController.js
+++ b/controllers/roomController.js
@@ -29,7 +29,7 @@ const createRoomName = async (req, res, next) => {
     const roomName = req.room_name;
 
     if (!roomName.length) {
-      errorGenerator({
+      throw await errorGenerator({
         statusCode: 400,
         message: "방 이름 길이는 0자 이상이어야 합니다.",
       });
@@ -50,7 +50,7 @@ const patchRoomName = async (req, res, next) => {
     const roomName = req.room_name;
 
     if (!roomName.length) {
-      errorGenerator({
+      throw await errorGenerator({
         statusCode: 400,
         message: "방 이름 길이는 0자 이상이어야 합니다.",
       });

--- a/middlewares/keyError.js
+++ b/middlewares/keyError.js
@@ -1,11 +1,8 @@
-const errorGenerator = require("../utils/errorGenerator");
-
 const roomId = async (req, res, next) => {
   const { room_id } = req.params;
 
-  if (!room_id) {
-    errorGenerator({ statusCode: 400, message: "KEY_ERROR: no room_id" });
-  }
+  if (!room_id)
+    return res.status(400).json({ message: "KEY_ERROR: no room_id" });
 
   next();
 };
@@ -13,9 +10,8 @@ const roomId = async (req, res, next) => {
 const roomName = async (req, res, next) => {
   const roomName = req.room_name;
 
-  if (!roomName) {
-    errorGenerator({ statusCode: 400, message: "KEY_ERROR: no room_name" });
-  }
+  if (!roomName)
+    return res.status(400).json({ message: "KEY_ERROR: no room_name" });
 
   next();
 };

--- a/middlewares/keyError.js
+++ b/middlewares/keyError.js
@@ -1,0 +1,23 @@
+const errorGenerator = require("../utils/errorGenerator");
+
+const roomId = async (req, res, next) => {
+  const { room_id } = req.params;
+
+  if (!room_id) {
+    errorGenerator({ statusCode: 400, message: "KEY_ERROR: no room_id" });
+  }
+
+  next();
+};
+
+const roomName = async (req, res, next) => {
+  const roomName = req.room_name;
+
+  if (!roomName) {
+    errorGenerator({ statusCode: 400, message: "KEY_ERROR: no room_name" });
+  }
+
+  next();
+};
+
+module.exports = { roomId, roomName };

--- a/middlewares/typeError.js
+++ b/middlewares/typeError.js
@@ -1,0 +1,31 @@
+const errorGenerator = require("../utils/errorGenerator");
+
+const roomId = async (req, res, next) => {
+  const { room_id } = req.params;
+
+  if (!(typeof room_id === Number)) {
+    errorGenerator({
+      statusCode: 400,
+      message: "TYPE_ERROR: room_Id's type should be number",
+    });
+  }
+
+  next();
+};
+
+const roomName = async (req, res, next) => {
+  const roomName = req.room_name;
+
+  if (!(typeof roomName === String)) {
+    errorGenerator({
+      statusCode: 400,
+      message: "TYPE_ERROR: room_name's type should be String",
+    });
+  }
+  next();
+};
+
+module.exports = {
+  roomId,
+  roomName,
+};

--- a/middlewares/typeError.js
+++ b/middlewares/typeError.js
@@ -1,14 +1,10 @@
-const errorGenerator = require("../utils/errorGenerator");
-
 const roomId = async (req, res, next) => {
   const { room_id } = req.params;
 
-  if (!(typeof room_id === Number)) {
-    errorGenerator({
-      statusCode: 400,
-      message: "TYPE_ERROR: room_Id's type should be number",
-    });
-  }
+  if (!(typeof room_id === Number))
+    return res
+      .status(400)
+      .json({ message: "TYPE_ERROR: room_Id's type should be number" });
 
   next();
 };
@@ -16,12 +12,11 @@ const roomId = async (req, res, next) => {
 const roomName = async (req, res, next) => {
   const roomName = req.room_name;
 
-  if (!(typeof roomName === String)) {
-    errorGenerator({
-      statusCode: 400,
-      message: "TYPE_ERROR: room_name's type should be String",
-    });
-  }
+  if (!(typeof roomName === String))
+    return res
+      .status(400)
+      .json({ message: "TYPE_ERROR: room_name's type should be String" });
+
   next();
 };
 

--- a/models/roomDao.js
+++ b/models/roomDao.js
@@ -1,0 +1,17 @@
+const { PrismaClient } = require("@prisma/client");
+const prisma = new PrismaClient();
+
+const getRoomName = async (roomId) => {};
+
+const getRoomUsers = async (roomId) => {};
+
+const createRoomName = async (roomName) => {};
+
+const patchRoomName = async (roomId, roomName) => {};
+
+module.exports = {
+  getRoomName,
+  getRoomUsers,
+  createRoomName,
+  patchRoomName,
+};

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,4 +1,8 @@
 const express = require("express");
 const router = express.Router();
 
+const roomRouter = require("./roomRoute");
+
+router.use("/rooms", roomRouter);
+
 module.exports = router;

--- a/routes/roomRoute.js
+++ b/routes/roomRoute.js
@@ -1,0 +1,38 @@
+const express = require("express");
+const router = express.Router();
+
+const roomController = require("../controllers/roomController");
+const keyError = require("../middlewares/keyError");
+const typeError = require("../middlewares/typeError");
+
+// GET
+router.get(
+  "/:room_id",
+  keyError.roomId,
+  typeError.roomId,
+  roomController.getRoomName
+);
+router.get(
+  "/:room_id/user",
+  keyError.roomId,
+  typeError.roomId,
+  roomController.getRoomUsers
+);
+
+// POST
+router.post(
+  "/",
+  keyError.roomName,
+  typeError.roomName,
+  roomController.createRoomName
+);
+
+// PATCH
+router.patch(
+  "/:room_id",
+  keyError.roomId,
+  keyError.roomName,
+  typeError.roomId,
+  typeError.roomName,
+  roomController.patchRoomName
+);

--- a/servieces/roomService.js
+++ b/servieces/roomService.js
@@ -1,0 +1,24 @@
+const roomDao = require("../models/roomDao");
+
+const getRoomName = async (roomId) => {
+  return await roomDao.getRoomName(roomId);
+};
+
+const getRoomUsers = async (roomId) => {
+  return await roomDao.getRoomUsers(roomId);
+};
+
+const createRoomName = async (roomName) => {
+  return await roomDao.createRoomName(roomName);
+};
+
+const patchRoomName = async (roomId, roomName) => {
+  return await roomDao.patchRoomName(roomId, roomName);
+};
+
+module.exports = {
+  getRoomName,
+  getRoomUsers,
+  createRoomName,
+  patchRoomName,
+};

--- a/utils/errorGenerator.js
+++ b/utils/errorGenerator.js
@@ -1,0 +1,8 @@
+async function errorGenerator(params) {
+  const { statusCode, message } = params;
+  const error = new Error(message);
+  error.statusCode = statusCode;
+  return error;
+}
+
+module.exports = errorGenerator;


### PR DESCRIPTION
## 설명


/rooms 관련 url controller, servive단까지 개발하였습니다.
반복되는 에러 미들웨어로 제작하여서 Router에서 사용하였습니다. 
에러 쉽게 만들어주는 유틸함수 제작하였습니다.


### errorGenertor 사용법

errorGenertor require한 다음에 
```
 throw await errorGenerator({
        statusCode: 400,
        message: "방 이름 길이는 0자 이상이어야 합니다.",
      });
```
이런식으로 사용하면 됩니다. 
 
## 기타

다오단 이어서 하겠습니다.